### PR TITLE
fix: Update Job interface to use string type for id and disable unuse…

### DIFF
--- a/src/entities/job/model.ts
+++ b/src/entities/job/model.ts
@@ -1,5 +1,5 @@
 export interface Job {
-  id: string | number;
+  id: string;
   title: string;
   company: string;
   location: string;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,8 +22,8 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },


### PR DESCRIPTION
**타입 변경 사항:**

* [`src/entities/job/model.ts`](diffhunk://#diff-5d5bb4e1bf4d1ec5adfd037066edda30a1c6a1c1b8c6295c9eb9d6c713a8413bL2-R2): 'Job' 인터페이스에서 'id' 속성을 'string' 또는 'number'가 아닌 항상 'string'이 되도록 수정했습니다.

**ESlint 규칙 변경 사항:**

* [`tsconfig.app.json`](diffhunk://#diff-e71ce96b0b270cb476d6bd8c44bf0cdf6f0db749e316374a54f1b14aff8d63ddL25-R26): 'noUnusedLocals' 및 'noUnusedParameters' 린트 규칙을 비활성화하여 사용되지 않는 로컬 변수와 파라미터를 허용합니다.