### PR TITLE
fix: update API client base URL to use relative path

### DIFF
--- a/src/shared/api/apiClient.ts
+++ b/src/shared/api/apiClient.ts
@@ -15,14 +15,12 @@ let isRefreshFailed = false;
 
 // API 클라이언트 생성 함수
 const createApiClient = (): AxiosInstance => {
-  // 기본 설정으로 axios 인스턴스 생성
   const axiosInstance = axios.create({
-    baseURL: BASE_URL,
+    baseURL: "/api",
     timeout: 10000,
     headers: {
       "Content-Type": "application/json",
     },
-    // 쿠키 기반 인증을 위해 credentials 포함 설정
     withCredentials: true,
   });
 


### PR DESCRIPTION
**설정 업데이트:**

* [`src/shared/api/apiClient.ts`](diffhunk://#diff-424c579c61cb722a51437336e17de5ebf6404418a63ecaa4a69cc354f620857cL18-L25): 새로운 API 엔드포인트를 반영하여 'baseURL'을 'BASE_URL'에서 '/api'로 변경했습니다.