### PR TITLE
refactor:AuthCallback 컴포넌트 Callback 비동기처리

### DIFF
--- a/apps/frontend/src/pages/auth/callback.tsx
+++ b/apps/frontend/src/pages/auth/callback.tsx
@@ -5,14 +5,36 @@ import { Spinner } from "@/components/ui/spinner";
 export default function AuthCallback() {
   const { handleOAuthCallback, isLoading, error } = useGoogleLogin();
   const [localError, setLocalError] = useState<string | null>(null);
+  const [callbackState, setCallbackState] = useState<string | null>("pending");
 
   useEffect(() => {
-    handleOAuthCallback().catch((err) => {
-      setLocalError(err.message || "인증 과정에서 오류가 발생했습니다.");
-    });
+    const processAuth = async () => {
+      setCallbackState("pending");
+      try {
+        const result = await handleOAuthCallback();
+        setCallbackState("success");
+      } catch (err: unknown) {
+        setLocalError(
+          err instanceof Error
+            ? err.message
+            : "인증 과정에서 오류가 발생했습니다."
+        );
+        setCallbackState("error");
+      }
+    };
+    processAuth();
   }, [handleOAuthCallback]);
 
-  if (error || localError) {
+  if (callbackState === "pending") {
+    return (
+      <div className='flex flex-col items-center justify-center min-h-screen p-4'>
+        <Spinner size='lg' />
+        <p className='mt-4 text-muted-foreground'>로그인 처리 중입니다...</p>
+      </div>
+    );
+  }
+
+  if (callbackState === "error") {
     return (
       <div className='flex flex-col items-center justify-center min-h-screen p-4'>
         <div className='mb-4 text-destructive'>


### PR DESCRIPTION
### AuthCallback 컴포넌트 업데이트
**(AS-IS)**
```typescript
  
  useEffect(() => {
    handleOAuthCallback().catch((err) => {
      setLocalError(err.message || "인증 과정에서 오류가 발생했습니다.");
    });
  }, [handleOAuthCallback]);

```

**(TO-BE)**
```typescript
  useEffect(() => {
    const processAuth = async () => {
      setCallbackState("pending");
      try {
        const result = await handleOAuthCallback();
        setCallbackState("success");
      } catch (err: unknown) {
        setLocalError(
          err instanceof Error
            ? err.message
            : "인증 과정에서 오류가 발생했습니다."
        );
        setCallbackState("error");
      }
    };
    processAuth();
  }, [handleOAuthCallback]);
```

-> 기존 로직에서 handleOAuthCallback 훅 실행 시 비동기로 실행되어, 작업이 완료되지 않은 상태에서 랜더링 조건부가 실행되어 버그 발생
-> async ~ await 구문을 활용하여 해당 비동기 처리부의 완료시점을 보장해줌